### PR TITLE
Obromios bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+*.rbc
+capybara-*.html
+.rspec
+/db/*.sqlite3
+/db/*.sqlite3-journal
+/db/*.sqlite3-[0-9]*
+/public/system
+/coverage/
+/spec/tmp
+*.orig
+rerun.txt
+pickle-email-*.html
+.DS_Store
+code/.DS_Store
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# TODO Comment out this rule if you are OK with secrets being uploaded to the repo
+config/initializers/secret_token.rb
+config/master.key
+
+# Only include if you have production secrets in this file, which is no longer a Rails default
+# config/secrets.yml
+
+# dotenv
+# TODO Comment out this rule if environment variables can be committed
+.env
+
+## Environment normalization:
+/.bundle
+/vendor/bundle
+
+# these should all be checked in to normalize the environment:
+# Gemfile.lock, .ruby-version, .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# if using bower-rails ignore default bower_components path bower.json files
+/vendor/assets/bower_components
+*.bowerrc
+bower.json
+
+# Ignore pow environment settings
+.powenv
+
+# Ignore Byebug command history file.
+.byebug_history
+
+# Ignore node_modules
+node_modules/
+
+# Ignore precompiled javascript packs
+/public/packs
+/public/packs-test
+/public/assets
+
+# Ignore yarn files
+/yarn-error.log
+yarn-debug.log*
+.yarn-integrity
+
+# Ignore uploaded files in development
+/storage/*
+!/storage/.keep
+.Rproj.user

--- a/MPU9250.h
+++ b/MPU9250.h
@@ -70,6 +70,7 @@ struct MPU9250Setting {
     uint8_t accel_fchoice {0x01};
     ACCEL_DLPF_CFG accel_dlpf_cfg {ACCEL_DLPF_CFG::DLPF_45HZ};
     COORDINATES_SEL coordinates_sel {COORDINATES_SEL::NED};
+};
 
 template <typename WireType>
 class MPU9250_ {
@@ -365,7 +366,7 @@ private:
         mag_resolution = get_mag_resolution(setting.mag_output_bits);
 
         
-        write_byte(MPU9250_ADDRESS, PWR_MGMT_1, 0x80);  // Write a one to bit 7 reset bit; toggle reset device
+        write_byte(mpu_i2c_addr, PWR_MGMT_1, 0x80);  // Write a one to bit 7 reset bit; toggle reset device
         delay(100);
         // wake up device
         write_byte(mpu_i2c_addr, PWR_MGMT_1, 0x00);  // Clear sleep mode bit (6), enable all sensors
@@ -392,13 +393,13 @@ private:
         // Set gyroscope full scale range
         // Range selects FS_SEL and GFS_SEL are 0 - 3, so 2-bit values are left-shifted into positions 4:3
 
-        uint8_t c = read_byte(MPU9250_ADDRESS, GYRO_CONFIG);  // get current GYRO_CONFIG register value
+        uint8_t c = read_byte(mpu_i2c_addr, GYRO_CONFIG);  // get current GYRO_CONFIG register value
         c = c & ~0xE0;                                        // Clear self-test bits [7:5]
         c = c & ~0x03;                                        // Clear Fchoice bits [1:0]
         c = c & ~0x18;                                        // Clear GYRO_FS_SEL bits [4:3]
         c = c | (uint8_t(setting.gyro_fs_sel) << 3);          // Set full scale range for the gyro
         c = c | (uint8_t(~setting.gyro_fchoice) & 0x03);       // Set Fchoice for the gyro by loading complement of Fchoice into Fchoice_b bits.
-        write_byte(MPU9250_ADDRESS, GYRO_CONFIG, c);          // Write new GYRO_CONFIG value to register
+        write_byte(mpu_i2c_addr, GYRO_CONFIG, c);          // Write new GYRO_CONFIG value to register
 
         // Set accelerometer full-scale range configuration
         c = read_byte(mpu_i2c_addr, ACCEL_CONFIG);     // get current ACCEL_CONFIG register value

--- a/MPU9250.h
+++ b/MPU9250.h
@@ -51,6 +51,11 @@ enum class ACCEL_DLPF_CFG : uint8_t {
     DLPF_420HZ,
 };
 
+enum class COORDINATES_SEL : uint8_t {
+    NED,
+    NWU,
+};
+
 static constexpr uint8_t MPU9250_WHOAMI_DEFAULT_VALUE{0x71};
 static constexpr uint8_t MPU9255_WHOAMI_DEFAULT_VALUE{0x73};
 
@@ -63,6 +68,7 @@ struct MPU9250Setting {
     GYRO_DLPF_CFG gyro_dlpf_cfg{GYRO_DLPF_CFG::DLPF_41HZ};
     uint8_t accel_fchoice{0x01};
     ACCEL_DLPF_CFG accel_dlpf_cfg{ACCEL_DLPF_CFG::DLPF_45HZ};
+    COORDINATES_SEL coordinates_sel {COORDINATES_SEL::NED};
 };
 
 template <typename WireType, uint8_t WHO_AM_I>
@@ -104,6 +110,11 @@ class MPU9250_ {
     // Other settings
     bool b_ahrs{true};
     bool b_verbose{false};
+    int mag_time_out {1000};  // Timeout for read_mag in ms
+    int experimental_mag_sliding_size {1};
+    int experimental_mag_sample_count {1500};
+    bool experimental_mag_flipping_on {false};
+    int experimental_mag_print_ratio {1};
 
     // I2C
     WireType* wire;
@@ -149,6 +160,29 @@ public:
     void ahrs(const bool b) {
         b_ahrs = b;
     }
+
+    void set_mag_time_out(const int milliseconds){
+        mag_time_out = milliseconds;
+    }
+
+    void set_mag_sliding_size(const int sliding_size){
+        experimental_mag_sliding_size = sliding_size;
+    }
+
+    void set_mag_sample_count(const int sample_count){
+        experimental_mag_sample_count = sample_count;
+    }
+    
+
+    void set_mag_filliping(const bool flipping_on){
+        experimental_mag_flipping_on = flipping_on;
+    }
+
+    void set_mag_print_ratio(const int print_ratio){
+        experimental_mag_print_ratio = print_ratio;
+    }
+    
+
 
     void calibrateAccelGyro() {
         calibrate_acc_gyro_impl();
@@ -214,7 +248,13 @@ public:
         float mn = +m[1];
         float me = -m[0];
         float md = +m[2];
-        quat_filter.update(an, ae, ad, gn, ge, gd, mn, me, md, q);
+
+        if(setting.coordinates_sel == COORDINATES_SEL::NED){
+            quat_filter.update( -an, -ae, -ad, gn, ge, gd, mn, me, md, q);
+        }
+        else{
+            quat_filter.update( an, ae, ad, gn, ge, gd, mn, me, md, q);
+        }
 
         if (!b_ahrs) {
             temperature_count = read_temperature_data();               // Read the adc values
@@ -300,6 +340,10 @@ public:
     }
     void setMagneticDeclination(const float d) { magnetic_declination = d; }
 
+    void selectFilter(QuatFilterSel sel) {
+        quat_filter.select_filter(sel);
+    }
+
     bool selftest() {
         return self_test_impl();
     }
@@ -310,6 +354,9 @@ private:
         gyro_resolution = get_gyro_resolution(setting.gyro_fs_sel);
         mag_resolution = get_mag_resolution(setting.mag_output_bits);
 
+        
+        write_byte(MPU9250_ADDRESS, PWR_MGMT_1, 0x80);  // Write a one to bit 7 reset bit; toggle reset device
+        delay(100);
         // wake up device
         write_byte(MPU9250_ADDRESS, PWR_MGMT_1, 0x00);  // Clear sleep mode bit (6), enable all sensors
         delay(100);                                     // Wait for all registers to reset
@@ -339,7 +386,7 @@ private:
         c = c & ~0x03;                                        // Clear Fchoice bits [1:0]
         c = c & ~0x18;                                        // Clear GYRO_FS_SEL bits [4:3]
         c = c | (uint8_t(setting.gyro_fs_sel) << 3);          // Set full scale range for the gyro
-        c = c | (uint8_t(setting.gyro_fchoice) & 0x03);       // Set Fchoice for the gyro
+        c = c | (uint8_t(~setting.gyro_fchoice) & 0x03);       // Set Fchoice for the gyro by loading complement of Fchoice into Fchoice_b bits.
         write_byte(MPU9250_ADDRESS, GYRO_CONFIG, c);          // Write new GYRO_CONFIG value to register
 
         // Set accelerometer full-scale range configuration
@@ -381,6 +428,7 @@ private:
         mag_bias_factory[0] = (float)(raw_data[0] - 128) / 256. + 1.;  // Return x-axis sensitivity adjustment values, etc.
         mag_bias_factory[1] = (float)(raw_data[1] - 128) / 256. + 1.;
         mag_bias_factory[2] = (float)(raw_data[2] - 128) / 256. + 1.;
+
         write_byte(AK8963_ADDRESS, AK8963_CNTL, 0x00);  // Power down magnetometer
         delay(10);
         // Configure the magnetometer for continuous read and highest resolution
@@ -479,6 +527,14 @@ private:
 
     void read_mag(int16_t* destination) {
         uint8_t raw_data[7];                                                 // x/y/z gyro register data, ST2 register stored here, must read ST2 at end of data acquisition
+        uint8_t ST1;
+        long int wait_time;
+        long int start_mag = millis();
+        do {
+            ST1 = read_byte(AK8963_ADDRESS, AK8963_ST1);
+            wait_time = millis() - start_mag;
+        } while(!(ST1 & 0x01) && (wait_time < mag_time_out));
+        if ((!ST1 & 0x01) && b_verbose) Serial.println("Warning - read_mag() timed out");
         if (read_byte(AK8963_ADDRESS, AK8963_ST1) & 0x01) {                  // wait for magnetometer data ready bit to be set
             read_bytes(AK8963_ADDRESS, AK8963_XOUT_L, 7, &raw_data[0]);      // Read the six raw data and ST2 registers sequentially into data array
             uint8_t c = raw_data[6];                                         // End data read by reading ST2 register
@@ -653,7 +709,10 @@ private:
         MAG_OUTPUT_BITS mag_output_bits_cache = setting.mag_output_bits;
         setting.mag_output_bits = MAG_OUTPUT_BITS::M16BITS;
         initAK8963();
-        collect_mag_data_to(mag_bias, mag_scale);
+
+        if(experimental_mag_flipping_on) collect_flipping_mag_data_to(mag_bias);
+        else collect_mag_data_to(mag_bias, mag_scale);
+        
 
         if (b_verbose) {
             Serial.println("Mag Calibration done!");
@@ -679,9 +738,50 @@ private:
         initAK8963();
     }
 
+    int16_t sliding_window(int16_t x_input, int n_window, int16_t* buffer){
+      for (int i = (n_window - 1); i > 0; --i){
+        buffer[i] = buffer[i - 1];
+      }
+      buffer[0] = x_input;
+      double sum = 0;
+      for (int i = 0; i < n_window; ++i) sum += buffer[i];
+      sum /= n_window;
+      return (int16_t) sum;
+    }
+
+    void collect_flipping_mag_data_to(float* m_bias) {
+        
+        char stage = 'A';
+        uint16_t sample_count = 100;
+        int16_t mag_temp[3] = {0, 0, 0};
+        long int mag_sum[3] = {0, 0, 0};
+        if (MAG_MODE == 0x02)
+            sample_count = 128;     // at 8 Hz ODR, new mag data is available every 125 ms
+        else if (MAG_MODE == 0x06)  // in this library, fixed to 100Hz
+
+        for (int i_stage = 0; i_stage < 4; ++i_stage)
+        {
+          Serial.print("Device should be put in Flipping position ");Serial.println(stage);
+          if(i_stage > 0) delay(10000);
+          Serial.print("Starting measurements for stage ");Serial.println(stage);
+          for (uint16_t ii = 0; ii < sample_count; ii++) {
+              read_mag(mag_temp);  // Read the mag data
+              for (int jj = 0; jj < 3; ++jj) mag_sum[jj] += mag_temp[jj];
+              delay(12);
+          }
+          ++stage;
+        }
+        Serial.println("Finished measurements");
+        float bias_resolution = get_mag_resolution(MAG_OUTPUT_BITS::M16BITS);
+        for (int jj = 0; jj < 3; ++jj){
+          m_bias[jj] = (float) mag_sum[jj] / sample_count / 4  * bias_resolution * mag_bias_factory[jj];
+        }
+    }
+
+
     void collect_mag_data_to(float* m_bias, float* m_scale) {
         if (b_verbose)
-            Serial.println("Mag Calibration: Wave device in a figure eight until done!");
+            Serial.println("Mag Calibration: Tumble device until done!");
         delay(4000);
 
         // shoot for ~fifteen seconds of mag data
@@ -689,20 +789,46 @@ private:
         if (MAG_MODE == 0x02)
             sample_count = 128;     // at 8 Hz ODR, new mag data is available every 125 ms
         else if (MAG_MODE == 0x06)  // in this library, fixed to 100Hz
-            sample_count = 1500;    // at 100 Hz ODR, new mag data is available every 10 ms
+            sample_count = experimental_mag_sample_count;    // at 100 Hz ODR, new mag data is available every 10 ms
 
-        int32_t bias[3] = {0, 0, 0}, scale[3] = {0, 0, 0};
+        int32_t bias[3] = {0, 0, 0};
+        float scale[3] = {0.0, 0.0, 0.0};
         int16_t mag_max[3] = {-32767, -32767, -32767};
         int16_t mag_min[3] = {32767, 32767, 32767};
         int16_t mag_temp[3] = {0, 0, 0};
+
+        const int n_sliding = experimental_mag_sliding_size;
+        int16_t mag_avg_buffer[3][n_sliding] = {0};
+        int16_t mag_avg[3] = {0, 0, 0};
         for (uint16_t ii = 0; ii < sample_count; ii++) {
             read_mag(mag_temp);  // Read the mag data
+
+            // initialize mag_avg_buffer
+            if(ii == 0){
+              for (int jj = 0; jj < 3; ++jj)
+              {
+                for (int kk = 0;kk < n_sliding; ++kk)
+                {
+                  mag_avg_buffer[jj][kk] = mag_temp[jj];
+                }
+              }
+            }
+
+            for (int jj = 0; jj < 3; ++jj){
+                mag_avg[jj] = sliding_window(mag_temp[jj], n_sliding, mag_avg_buffer[jj]);
+            }
             for (int jj = 0; jj < 3; jj++) {
-                if (mag_temp[jj] > mag_max[jj]) mag_max[jj] = mag_temp[jj];
-                if (mag_temp[jj] < mag_min[jj]) mag_min[jj] = mag_temp[jj];
+                if (mag_avg[jj] > mag_max[jj]) mag_max[jj] = mag_avg[jj];
+                if (mag_avg[jj] < mag_min[jj]) mag_min[jj] = mag_avg[jj];
             }
             if (MAG_MODE == 0x02) delay(135);  // at 8 Hz ODR, new mag data is available every 125 ms
             if (MAG_MODE == 0x06) delay(12);   // at 100 Hz ODR, new mag data is available every 10 ms
+            if (b_verbose && (ii % experimental_mag_print_ratio)  == 0){
+                Serial.print(mag_avg[0]);Serial.print(", ");
+                Serial.print(mag_avg[1]);Serial.print(", ");
+                Serial.println(mag_avg[2]);
+            }
+
         }
 
         if (b_verbose) {
@@ -728,9 +854,11 @@ private:
         m_bias[2] = (float)bias[2] * bias_resolution * mag_bias_factory[2];
 
         // Get soft iron correction estimate
-        scale[0] = (mag_max[0] - mag_min[0]) / 2;  // get average x axis max chord length in counts
-        scale[1] = (mag_max[1] - mag_min[1]) / 2;  // get average y axis max chord length in counts
-        scale[2] = (mag_max[2] - mag_min[2]) / 2;  // get average z axis max chord length in counts
+        //*** multiplication by mag_bias_factory added in accordance with the following comment
+        //*** https://github.com/kriswiner/MPU9250/issues/456#issue-836657973
+        scale[0] = (float)(mag_max[0] - mag_min[0]) * mag_bias_factory[0] / 2;  // get average x axis max chord length in counts
+        scale[1] = (float)(mag_max[1] - mag_min[1]) * mag_bias_factory[1] / 2;  // get average y axis max chord length in counts
+        scale[2] = (float)(mag_max[2] - mag_min[2]) * mag_bias_factory[2]/ 2;  // get average z axis max chord length in counts
 
         float avg_rad = scale[0] + scale[1] + scale[2];
         avg_rad /= 3.0;

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ void loop() {
 - accel/gyro/mag offsets are **NOT stored** to register if the MPU has powered off ([app note](https://www.digikey.com/en/pdf/i/invensense/mpu-hardware-offset-registers))
 - need to **set all offsets at every bootup by yourself** (or calibrate at every bootup)
 - device should be stay still during accel/gyro calibration
-- round device around during mag calibration
+- During magnetometer calibration, perform a series of tumbling actions with the aim of rotating the MPU9250 through as many angular orientations as possible. If possible, print out scatter plots of the x-y, y-z, and z-y axes readings to ensure that the end points are being captured. Please see this [article](https://github.com/kriswiner/MPU6050/wiki/Simple-and-Effective-Magnetometer-Calibration) and this [technical note](http://www.philomaths.org/papers/calibration) for more information on magnetometer calibration. The appendix of the tecnical note contains information on experimental methods for calibration.
 
 ``` C++
 #include "MPU9250.h"
@@ -163,6 +163,18 @@ You can find magnetic declination in your city [here](http://www.magnetic-declin
 For more details, see [wiki](https://en.wikipedia.org/wiki/Magnetic_declination).
 
 
+### Quaternion Filter
+
+You can choose quaternion filter using `void selectFilter(QuatFilterSel sel)`. Available quaternion filters are listed below.
+
+```C++
+enum class QuatFilterSel {
+    NONE,
+    MADGWICK, // default
+    MAHONY,
+};
+```
+
 
 ### Other I2C library
 
@@ -258,7 +270,20 @@ void setMagBias(const float x, const float y, const float z);
 void setMagScale(const float x, const float y, const float z);
 void setMagneticDeclination(const float d);
 
+void selectFilter(QuatFilterSel sel);
 bool selftest();
+```
+
+## Experimental APIs
+**Warning:** these may be altered or deleted in next release.
+
+These APIs are for experimenting with magnetometer calibration methods.
+``` C++
+void set_mag_time_out(const int milliseconds);
+void set_mag_sliding_size(const int sliding_size);
+void set_mag_sample_count(const int sample_count);
+void set_mag_filliping(const bool flipping_on);
+void set_mag_print_ratio(const int print_ratio);
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ void loop() {
 - accel/gyro/mag offsets are **NOT stored** to register if the MPU has powered off ([app note](https://www.digikey.com/en/pdf/i/invensense/mpu-hardware-offset-registers))
 - need to **set all offsets at every bootup by yourself** (or calibrate at every bootup)
 - device should be stay still during accel/gyro calibration
-- During magnetometer calibration, perform a series of tumbling actions with the aim of rotating the MPU9250 through as many angular orientations as possible. If possible, print out scatter plots of the x-y, y-z, and z-y axes readings to ensure that the end points are being captured. Please see this [article](https://github.com/kriswiner/MPU6050/wiki/Simple-and-Effective-Magnetometer-Calibration) and this [technical note](http://www.philomaths.org/papers/calibration) for more information on magnetometer calibration. The appendix of the tecnical note contains information on experimental methods for calibration.
+- round device around during mag calibration
 
 ``` C++
 #include "MPU9250.h"
@@ -276,18 +276,6 @@ void setMagneticDeclination(const float d);
 
 void selectFilter(QuatFilterSel sel);
 bool selftest();
-```
-
-## Experimental APIs
-**Warning:** these may be altered or deleted in next release.
-
-These APIs are for experimenting with magnetometer calibration methods.
-``` C++
-void set_mag_time_out(const int milliseconds);
-void set_mag_sliding_size(const int sliding_size);
-void set_mag_sample_count(const int sample_count);
-void set_mag_filliping(const bool flipping_on);
-void set_mag_print_ratio(const int print_ratio);
 ```
 
 ## License


### PR DESCRIPTION
This is similar to PR #49 but with experimental features and calibration enhancements removed.

## Fixes for issue #33 (Intermittent errors in reading mag data)
- Add a while loop in read_mag() to check ST1 is set correctly
- Added a time out for the while loop
- Added a setting, mpu.set_mag_time_out to control length of timeout

## Fix for issue #34 (Gyro readings noisy)
- Inverted application of setting.gyro_fchoice in initMPU9250()

## Fix for issue #39 (initMPU9250() is not initializing the accelerometer)
- Added a reset at beginning of initMPU9250()

## Fix for issue #45 (Consistent use of fuse values)
- In collect_mag_data(), used mag_bias_factory[i] as a multiplicative factor in calculation of scale[i]

## Fix for issues #46, #48, #42 and #30.

These issues are 

- What is the correct way to transform the raw readings for the quaternion update (#46)
- Using setMagneticDeclination does not work properly (#48)
- Yaw offset problem (#42)
- Wrong Linear Acceleration readings (#30)
- Root cause of all these issues was related to the choice of coordinate systems.
- The fix was to provide a setting to switch between coordinate systems.
- At present, two options are provided, NED and NWU.  NWU is only partially supported (see below)

## Partial support for NWU coordinate systems
- The commit on January 5 (455a9efd109cb5c9f0bc96710979cb451ef2fae9), made a change to the coordinate system being fed into the quaternion filter (see issue #46).  Prior to this, the coordinate system was the same used by Kris Winer, NED. After this change there was a new coordinate system, which until clarification is being called NWU.
- This was a breaking change that caused a number of other issues (#48, #42, and #30). There maybe other problems caused by the breaking change that have yet to be detected.   Accordingly, a setting has been introduced that allows the coordinate system to be set back to NED.  This fixes these issues.
- There is also a settings option to change the coordinate system to NWU, but using this option will cause the issues in #48, #42, and #30 to reappear.  As well, there is an extremely long settling time for rotations in the horizontal plane.  It may possible to rectify each issue (and other possible undetected issues) by making changes specific the NWU coordinate system.
- Given using the NWU system currently causes breaking changes, it is recommended that the default coordinate system be reverted to NED, until the NWU coordinate option is fully implemented. If no further work is to be done on the NWU coordinate system, it is recommended that it is removed as an option.