### PR TITLE
fix Serial print mag_min/mag_max order

### DIFF
--- a/MPU9250.h
+++ b/MPU9250.h
@@ -749,14 +749,14 @@ private:
 
         if (b_verbose) {
             Serial.println("mag x min/max:");
-            Serial.println(mag_max[0]);
             Serial.println(mag_min[0]);
+            Serial.println(mag_max[0]);
             Serial.println("mag y min/max:");
-            Serial.println(mag_max[1]);
             Serial.println(mag_min[1]);
+            Serial.println(mag_max[1]);
             Serial.println("mag z min/max:");
-            Serial.println(mag_max[2]);
             Serial.println(mag_min[2]);
+            Serial.println(mag_max[2]);
         }
 
         // Get hard iron correction


### PR DESCRIPTION
Hi @hideakitai 

I thought it would be displayed in the order of the min/max values of the geomagnetic sensor, 
but in fact it was the max/min values in that order.

Is this a specification? 