### PR TITLE
Made a sleep function

### DIFF
--- a/MPU9250.h
+++ b/MPU9250.h
@@ -156,6 +156,16 @@ public:
         has_connected = true;
         return true;
     }
+	
+	void sleep(bool b){
+		byte c = read_byte(mpu_i2c_addr, PWR_MGMT_1); // read the value, change sleep bit to match b, write byte back to register
+		if(b){
+			c = c | 0x40; // sets the sleep bit
+		} else {
+			c = c & 0xBF; // mask 1011111 keeps all the previous bits
+		}
+		write_byte(mpu_i2c_addr, PWR_MGMT_1, c);
+	}
 
     void verbose(const bool b) {
         b_verbose = b;

--- a/MPU9250.h
+++ b/MPU9250.h
@@ -157,15 +157,15 @@ public:
         return true;
     }
 	
-	void sleep(bool b){
-		byte c = read_byte(mpu_i2c_addr, PWR_MGMT_1); // read the value, change sleep bit to match b, write byte back to register
-		if(b){
-			c = c | 0x40; // sets the sleep bit
-		} else {
-			c = c & 0xBF; // mask 1011111 keeps all the previous bits
-		}
-		write_byte(mpu_i2c_addr, PWR_MGMT_1, c);
-	}
+    void sleep(bool b){
+        byte c = read_byte(mpu_i2c_addr, PWR_MGMT_1); // read the value, change sleep bit to match b, write byte back to register
+        if(b){
+            c = c | 0x40; // sets the sleep bit
+        } else {
+            c = c & 0xBF; // mask 1011111 keeps all the previous bits
+        }
+        write_byte(mpu_i2c_addr, PWR_MGMT_1, c);
+    }
 
     void verbose(const bool b) {
         b_verbose = b;


### PR DESCRIPTION
I used [this documentation](https://cdn.sparkfun.com/assets/learn_tutorials/5/5/0/MPU-9250-Register-Map.pdf) to make a sleep function. Passing true to the function will put the MPU 9250 to sleep while preserving the values of the other bits in the register. Passing false would wake it back up.

I wanted to include this functionality because it could help with saving power when the MPU isn't needed.